### PR TITLE
Smart battery sense support

### DIFF
--- a/victron_ble/cli.py
+++ b/victron_ble/cli.py
@@ -20,6 +20,12 @@ class DeviceKeyParam(click.ParamType):
                 addr = parts[0].strip()
                 key = parts[1].strip()
                 return (addr, key)
+            if len(parts) > 2:
+                parts = value.split("|")
+                if len(parts) == 2:
+                    addr = parts[0].strip()
+                    key = parts[1].strip()
+                    return (addr, key)
 
         self.fail(f"{value} is not a valid <addr>:<key> pair", param, ctx)
 

--- a/victron_ble/devices/__init__.py
+++ b/victron_ble/devices/__init__.py
@@ -1,18 +1,20 @@
 from construct import Int16ul
 
 from victron_ble.devices.base import Device
-from victron_ble.devices.battery_monitor import BatteryMonitor, BatterySense
+from victron_ble.devices.battery_monitor import BatteryMonitor
+from victron_ble.devices.smart_battery_sense import SmartBatterySense
 
-__all__ = ["Device", "BatteryMonitor"]
+
+__all__ = ["Device", "BatteryMonitor", "SmartBatterySense"]
 
 MODEL_MAPPING = {
-    0xA381: BatteryMonitor,  # BMV-712 Smart
-    0xA382: BatteryMonitor,  # BMV-710H Smart
-    0xA383: BatteryMonitor,  # BMV-712 Smart Rev2
-    0xA389: BatteryMonitor,  # SmartShunt 500A/50mV
-    0xA38A: BatteryMonitor,  # SmartShunt 1000A/50mV
-    0xA38B: BatteryMonitor,  # SmartShunt 2000A/50mV
-    0xA3A4: BatterySense,  # Smart Battery Sense
+    0xA381: BatteryMonitor,     # BMV-712 Smart
+    0xA382: BatteryMonitor,     # BMV-710H Smart
+    0xA383: BatteryMonitor,     # BMV-712 Smart Rev2
+    0xA389: BatteryMonitor,     # SmartShunt 500A/50mV
+    0xA38A: BatteryMonitor,     # SmartShunt 1000A/50mV
+    0xA38B: BatteryMonitor,     # SmartShunt 2000A/50mV
+    0xA3A4: SmartBatterySense,  # Smart Battery Sense
 }
 
 

--- a/victron_ble/devices/smart_battery_sense.py
+++ b/victron_ble/devices/smart_battery_sense.py
@@ -1,0 +1,61 @@
+from construct import (
+    BitStruct,
+    FixedSized,
+    Flag,
+    GreedyBytes,
+    Int8sl,
+    Int16sl,
+    Int16ul,
+    Int24sl,
+    Struct,
+)
+from Crypto.Cipher import AES
+
+from victron_ble.devices.base import Device
+
+
+class SmartBatterySense(Device):
+
+    CONTAINER = Struct(
+        "prefix" / FixedSized(2, GreedyBytes),
+        # Model ID
+        "device_id" / Int16ul,
+        # Battery monitor vs DC Energy Meter
+        "battery_monitor_mode" / Int8sl,
+        # IV for encryption
+        "iv" / Int16ul,
+        "encrypted_data" / FixedSized(16, GreedyBytes),
+    )
+
+    PACKET = Struct(
+        # Unknown bytes
+        "uk1_2b" / Int16ul,
+        # Voltage reading in 0.1v increments
+        "voltage" / Int16ul,
+        # Unknown bytes
+        "uk2_2b" / Int16ul,
+        # Temperaturee in Kelvin
+        "temperature" / Int16ul,
+        # Throw away any extra bytes
+        GreedyBytes,
+    )
+
+    def parse(self, data: bytes):
+        container = self.CONTAINER.parse(data)
+
+        # The first byte of advertised data seems to match the first byte of the advertisement key
+        cipher = AES.new(
+            bytes.fromhex(self.advertisement_key),
+            AES.MODE_OFB,
+            iv=container.iv.to_bytes(16, "little"),
+        )
+        decrypted = cipher.decrypt(container.encrypted_data[1:] + b"\x0f")
+
+        pkt = self.PACKET.parse(decrypted)
+
+        return {
+            "voltage": pkt.voltage / 100,
+            "temperatureK": pkt.temperature / 100,
+            "temperatureC": round((pkt.temperature / 100) - 273.15, 2),
+            "temperatureF": round(((pkt.temperature / 100) * (9/5)) - 459.67, 2),
+        }


### PR DESCRIPTION
### Summary :memo:
Adding support for Victron Smart Battery Sense
Allow to use | as a separator for MAC address and Key
