### PR TITLE
Confirm that BMV-712 provides the same data as the smartshunt

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Disclaimer: This software is not an officially supported interface by Victron an
 
 **Supported Devices:**
 
-* SmartShunt 500A/500mv (and likely BMV-712/702) provide the following data:
+* SmartShunt 500A/500mv and BMV-712/702 provide the following data:
     * Voltage
     * Alarm status
     * Current


### PR DESCRIPTION
Hah, I've just spent half a day trying to reverse-engineer the protocol, myself. I'm glad to see I was on the right track, but you got many more details figured out :)

For a BMV-712, the data looks correct.