### PR TITLE
Make Scanner easier to override

### DIFF
--- a/victron_ble/exceptions.py
+++ b/victron_ble/exceptions.py
@@ -1,0 +1,6 @@
+class UnknownDeviceError(Exception):
+    pass
+
+
+class AdvertisementKeyMissingError(Exception):
+    pass


### PR DESCRIPTION
At the moment, if you want to do something with this as a library, you end up reimplementing a lot of the current `callback()` method. We can factor those functions out:

1. Move the device lookup from callback() into a helper function that subclasses can use.
2. Allow subclasses to customize advertisement key loading.