### PR TITLE
Report 65535 remaining minutes of runtime as infinity

### DIFF
--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -1,3 +1,4 @@
+from math import isinf
 from victron_ble.devices.battery_monitor import BatteryMonitor, AuxMode
 
 
@@ -10,7 +11,7 @@ class TestBatteryMonitor:
         assert actual.get_aux_mode() == AuxMode.DISABLED
         assert actual.get_consumed_ah() == 50.0
         assert actual.get_current() == 0
-        assert actual.get_remaining_mins() == 65535
+        assert isinf(actual.get_remaining_mins())
         assert actual.get_soc() == 50.0
         assert actual.get_voltage() == 12.53
         assert actual.get_high_starter_battery_voltage_alarm() == False

--- a/victron_ble/devices/battery_monitor.py
+++ b/victron_ble/devices/battery_monitor.py
@@ -1,3 +1,4 @@
+from math import inf
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -187,9 +188,12 @@ class BatteryMonitor(Device):
         pkt = self.PACKET.parse(decrypted)
 
         aux_mode = AuxMode(pkt.current & 0b11)
+        remaining_mins = pkt.remaining_mins
+        if remaining_mins == 0xFFFF:
+            remaining_mins = inf
 
         parsed = {
-            "remaining_mins": pkt.remaining_mins,
+            "remaining_mins": remaining_mins,
             "aux_mode": aux_mode,
             "current": (pkt.current >> 2) / 1000,
             "voltage": pkt.voltage / 100,


### PR DESCRIPTION
I'm in two minds about this change. It matches what the app shows, but will probably cause downstream data issues. (JSON can't render infinity, for example)

Have you already considered this?