### PR TITLE
Add dcdc converter

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ A0:F4:78:02:0F:E1|0df4d0395b7d1a876c0c33ecb9e70dcd
 
 **Windows**
 
-Not supported yet. Please figure this out and contribute some
-instructions.
+1. Download the VictronConnect installer from the Victron website and install.
+2. Pair with your device at least once to transfer keys
+3. Open Explorer, navigate to ```%AppData%\Local\Victron Energy\Victron Connect\```
+4. Open [SQLite Viewer](https://inloop.github.io/sqlite-viewer/) in a web browser of your choice
+5. Drag and drop the ```d25b6546b47ebb21a04ff86a2c4fbb76.sqlite``` file from Explorer into the SQLite Viewer window
+
 
 #### Reading data
 

--- a/victron_ble/devices/__init__.py
+++ b/victron_ble/devices/__init__.py
@@ -7,6 +7,7 @@ from victron_ble.devices.battery_monitor import AuxMode, BatteryMonitor
 from victron_ble.devices.battery_sense import BatterySense
 from victron_ble.devices.dc_energy_meter import DcEnergyMeter
 from victron_ble.devices.solar_charger import SolarCharger
+from victron_ble.devices.dcdc_converter import DcDcConverter
 
 __all__ = [
     "AuxMode",
@@ -15,6 +16,7 @@ __all__ = [
     "BatteryMonitor",
     "DcEnergyMeter",
     "SolarCharger",
+    "DcDcConverter",
 ]
 
 # Add to this list if a device should be forced to use a particular implementation
@@ -42,7 +44,7 @@ def detect_device_type(data: bytes) -> Optional[Type[Device]]:
     elif mode == 0x8:  # AcCharger
         pass
     elif mode == 0x4:  # DcDcConverter
-        pass
+        return DcDcConverter
     elif mode == 0x3:  # Inverter
         pass
     elif mode == 0x6:  # InverterRS

--- a/victron_ble/devices/base.py
+++ b/victron_ble/devices/base.py
@@ -25,6 +25,55 @@ class OperationMode(Enum):
     BATTERY_SAFE = 248
     EXTERNAL_CONTROL = 252
 
+class ChargerError(Enum):
+    NONE = 0
+    VOLTAGE_TOO_HIGH = 2
+    TEMPERATURE_TOO_HIGH = 17
+    OVERCURRENT = 18
+    CURRENT_REVERSED = 19
+    BULK_TIME_EXCEEDED = 20
+    CURRENT_SENSOR_ISSUE = 21
+    TERMINALS_OVERHEATED = 26
+    CONVERTER_ISSUE = 28
+    INPUT_VOLTAGE_TOO_HIGH = 33
+    INPUT_CURRENT_TOO_HIGH = 34
+    INPUT_SHUTDOWN_BATT = 38
+    INPUT_SHUTDOWN_CURRENT = 39
+    LOST_COMMS = 65
+    CHARGE_SYNC_ISSUE = 66
+    BMS_CONNECTION_LOST = 67
+    NETWORK_MISCONFIGURED = 68
+    FACTORY_CALIBRATION_LOST = 116
+    INVALID_FIRMWARE = 117
+    USER_SETTINGS_INVALID = 119
+    
+class OffReason(Enum):
+    NONE = 0x00000000
+    NO_INPUT_POWER = 0x00000001
+    SWITCHED_OFF_SWITCH = 0x00000002
+    SWITCHED_OFF_REGISTER = 0x00000004
+    REMOTE_INPUT = 0x00000008
+    PROTECTION_ACTIVE = 0x00000010
+    PAY_AS_YOU_GO_OUT_OF_CREDIT = 0x00000020
+    BMS = 0x00000040
+    ENGINE_SHUTDOWN = 0x00000080
+    ANALYSING_INPUT_VOLTAGE = 0x00000100
+
+class AlarmReason(Enum):
+    LOW_VOLTAGE = 1
+    HIGH_VOLTAGE = 2
+    LOW_SOC = 4
+    LOW_STARTER_VOLTAGE = 8
+    HIGH_STARTER_VOLTAGE = 16
+    LOW_TEMPERATURE = 32
+    HIGH_TEMPERATURE = 64
+    MID_VOLTAGE = 128
+    OVERLOAD = 256
+    DC_RIPPLE = 512
+    LOW_V_AC_OUT = 1024
+    HIGH_V_AC_OUT = 2048
+    SHORT_CIRCUIT = 4096
+    BMS_LOCKOUT = 8192
 
 # Sourced from VE.Direct docs
 MODEL_ID_MAPPING = {
@@ -164,6 +213,26 @@ MODEL_ID_MAPPING = {
     0xA38B: "SmartShunt 2000A/50mV",
     0xA3A4: "Smart Battery Sense",
     0xA3A5: "Smart Battery Sense",
+    0xA3C0: "Orion Smart 12V|12V-18A Isolated DC-DC Charger",
+    0xA3C8: "Orion Smart 12V|12V-30A Isolated DC-DC Charger",
+    0xA3D0: "Orion Smart 12V|12V-30A Non-isolated DC-DC Charger",
+    0xA3C1: "Orion Smart 12V|24V-10A Isolated DC-DC Charger",
+    0xA3C9: "Orion Smart 12V|24V-15A Isolated DC-DC Charger",
+    0xA3D1: "Orion Smart 12V|24V-15A Non-isolated DC-DC Charger",
+    0xA3C2: "Orion Smart 24V|12V-20A Isolated DC-DC Charger",
+    0xA3CA: "Orion Smart 24V|12V-30A Isolated DC-DC Charger",
+    0xA3D2: "Orion Smart 24V|12V-30A Non-isolated DC-DC Charger",
+    0xA3C3: "Orion Smart 24V|24V-12A Isolated DC-DC Charger",
+    0xA3CB: "Orion Smart 24V|24V-17A Isolated DC-DC Charger",
+    0xA3D3: "Orion Smart 24V|24V-17A Non-isolated DC-DC Charger",
+    0xA3C4: "Orion Smart 24V|48V-6A Isolated DC-DC Charger",
+    0xA3CC: "Orion Smart 24V|48V-8.5A Isolated DC-DC Charger",
+    0xA3C5: "Orion Smart 48V|12V-20A Isolated DC-DC Charger",
+    0xA3CD: "Orion Smart 48V|12V-30A Isolated DC-DC Charger",
+    0xA3C6: "Orion Smart 48V|24V-12A Isolated DC-DC Charger",
+    0xA3CE: "Orion Smart 48V|24V-16A Isolated DC-DC Charger",
+    0xA3C7: "Orion Smart 48V|48V-6A Isolated DC-DC Charger",
+    0xA3CF: "Orion Smart 48V|48V-8.5A Isolated DC-DC Charger",
 }
 
 

--- a/victron_ble/devices/dcdc_converter.py
+++ b/victron_ble/devices/dcdc_converter.py
@@ -1,0 +1,70 @@
+from construct import Int8sl, Int8ul, Int16sl, Int16ul, Int32ul, Struct, GreedyBytes
+from typing import Optional
+
+from victron_ble.devices.base import Device, DeviceData, OperationMode, ChargerError, OffReason
+
+
+class DcDcConverterData(DeviceData):
+    def get_charge_state(self) -> OperationMode:
+        """
+        Return an enum indicating the current charging state
+        """
+        return self._data["device_state"]
+
+    def get_charger_error(self) -> ChargerError:
+        """
+        Return an enum indicating the error code
+        """
+        return self._data["charger_error"]
+
+    def get_input_voltage(self) -> float:
+        """
+        Return the input voltage in volts
+        """
+        return self._data["input_voltage"]
+
+    def get_output_voltage(self) -> float:
+        """
+        Return the output voltage in volts
+        """
+        return self._data["output_voltage"]
+
+    def get_off_reason(self) -> OffReason:
+        """
+        Return an error code stating the reason for the output to be off
+        """
+        return self._data["off_reason"]
+
+
+class DcDcConverter(Device):
+
+    PACKET = Struct(
+        # Charge State:   0 - Off
+        #                 3 - Bulk
+        #                 4 - Absorption
+        #                 5 - Float
+        "device_state" / Int8ul,
+        # Charger Error Code
+        "charger_error" / Int8ul,
+        # Input voltage reading in 0.01V increments
+        "input_voltage" / Int16ul,
+        # Output voltage in 0.01V
+        "output_voltage" / Int16sl,
+        # Reason for Charger Off
+        "off_reason" / Int32ul,
+        GreedyBytes,
+    )
+
+    def parse(self, data: bytes) -> DcDcConverterData:
+        decrypted = self.decrypt(data)
+        pkt = self.PACKET.parse(decrypted)
+
+        parsed = {
+            "device_state": OperationMode(pkt.device_state),
+            "charger_error": ChargerError(pkt.charger_error),
+            "input_voltage": pkt.input_voltage / 100,
+            "output_voltage": pkt.output_voltage / 100,
+            "off_reason": OffReason(pkt.off_reason),
+        }
+
+        return DcDcConverterData(self.get_model_id(data), parsed)


### PR DESCRIPTION
### Summary :memo:
Added support for Orion Smart DC/DC chargers

### Details
_Describe more what you did on changes._
1. Added all Orion Smart product IDs to devices/base.py
2. Wrote parser logic to parse datagrams from Orion Smart DC/DC Converters.
3. Checked against live device on our boat, input/output voltage and operation mode match what's shown in the VictronConnect app.

### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval
