### PR TITLE
Add support for VEBus connection to inverter-charger

### DIFF
--- a/tests/test_vebus.py
+++ b/tests/test_vebus.py
@@ -1,0 +1,37 @@
+from victron_ble.devices.vebus import VEBus
+from victron_ble.devices.base import OperationMode, ACInState
+
+
+class TestVEBus:
+    def test_parse_data(self) -> None:
+        data = "100380270c1252dad26f0b8eb39162074d140df410"
+        actual = VEBus("da3f5fa2860cb1cf86ba7a6d1d16b9dd").parse(bytes.fromhex(data))
+
+        assert actual.get_device_state() == OperationMode.FLOAT
+        assert actual.get_battery_voltage() == 14.45
+        assert actual.get_battery_current() == 23.2
+        assert actual.get_ac_in_state() == ACInState.AC_IN_1
+        assert actual.get_ac_in_power() == 1459
+        assert actual.get_ac_out_power() == 1046
+        assert actual.get_battery_temperature() == 24
+        assert actual.get_soc() == None
+
+    def test_inverter(self) -> None:
+        data = "100380270ce1b2dabd34912a6ecec963899227a220"
+        actual = VEBus("da3f5fa2860cb1cf86ba7a6d1d16b9dd").parse(bytes.fromhex(data))
+
+        assert actual.get_device_state() == OperationMode.INVERTING
+        assert actual.get_battery_voltage() == 12.43
+        assert actual.get_battery_current() == -5.9
+        assert actual.get_ac_in_state() == ACInState.NOT_CONNECTED
+        assert actual.get_ac_in_power() == 0
+        assert actual.get_ac_out_power() == 45
+        assert actual.get_battery_temperature() == 30
+        assert actual.get_soc() == None
+
+    def test_off(self) -> None:
+        data = "100380270c65b8dad9dd594c7f57d1de9e27a3e2ab"
+        actual = VEBus("da3f5fa2860cb1cf86ba7a6d1d16b9dd").parse(bytes.fromhex(data))
+
+        assert actual.get_device_state() == OperationMode.OFF
+        assert actual.get_model_name() == "Victron Multiplus II 12/3000/120-50 2x120V"

--- a/victron_ble/devices/__init__.py
+++ b/victron_ble/devices/__init__.py
@@ -8,6 +8,7 @@ from victron_ble.devices.battery_sense import BatterySense
 from victron_ble.devices.dc_energy_meter import DcEnergyMeter
 from victron_ble.devices.dcdc_converter import DcDcConverter
 from victron_ble.devices.solar_charger import SolarCharger
+from victron_ble.devices.vebus import VEBus
 
 __all__ = [
     "AuxMode",
@@ -15,6 +16,7 @@ __all__ = [
     "DeviceData",
     "BatteryMonitor",
     "DcEnergyMeter",
+    "InverterCharger",
     "SolarCharger",
 ]
 
@@ -57,6 +59,6 @@ def detect_device_type(data: bytes) -> Optional[Type[Device]]:
     elif mode == 0x1:  # SolarCharger
         return SolarCharger
     elif mode == 0xC:  # VE.Bus
-        pass
+        return VEBus
 
     return None

--- a/victron_ble/devices/__init__.py
+++ b/victron_ble/devices/__init__.py
@@ -16,8 +16,8 @@ __all__ = [
     "DeviceData",
     "BatteryMonitor",
     "DcEnergyMeter",
-    "InverterCharger",
     "SolarCharger",
+    "VEBus",
 ]
 
 # Add to this list if a device should be forced to use a particular implementation

--- a/victron_ble/devices/base.py
+++ b/victron_ble/devices/base.py
@@ -195,6 +195,14 @@ class AlarmReason(Enum):
     BMS_LOCKOUT = 8192
 
 
+# Sourced from Victron extra-manufacturer-data-2022-12-14.pdf
+class ACInState(Enum):
+    AC_IN_1 = 0
+    AC_IN_2 = 1
+    NOT_CONNECTED = 2
+    UNKNOWN = 3
+
+
 # Sourced from VE.Direct docs
 MODEL_ID_MAPPING = {
     0x203: "BMV-700",
@@ -353,6 +361,7 @@ MODEL_ID_MAPPING = {
     0xA3CE: "Orion Smart 48V|24V-16A Isolated DC-DC Charger",
     0xA3C7: "Orion Smart 48V|48V-6A Isolated DC-DC Charger",
     0xA3CF: "Orion Smart 48V|48V-8.5A Isolated DC-DC Charger",
+    0x2780: "Victron Multiplus II 12/3000/120-50 2x120V",
 }
 
 

--- a/victron_ble/devices/vebus.py
+++ b/victron_ble/devices/vebus.py
@@ -84,7 +84,7 @@ class VEBus(Device):
 
         ac_in_bytes = int.from_bytes(pkt.ac_in_and_ac_out_power[0:3], "little")
         ac_in_power = ac_in_bytes & 0x03FFFF
-        if ac_in_bytes & 0x80000:
+        if ac_in_bytes & 0x40000:
             ac_in_power *= -1
 
         ac_out_bytes = int.from_bytes(pkt.ac_in_and_ac_out_power[2:5], "little") >> 2

--- a/victron_ble/devices/vebus.py
+++ b/victron_ble/devices/vebus.py
@@ -1,0 +1,114 @@
+from construct import Bytes, GreedyBytes, Int8ul, Int16sl, Int16ul, Struct
+
+from victron_ble.devices.base import ACInState, Device, DeviceData, OperationMode
+
+
+class VEBusData(DeviceData):
+    def get_device_state(self) -> OperationMode:
+        """
+        Return an enum indicating the device state
+        """
+        return self._data["device_state"]
+
+    def get_ac_in_state(self) -> ACInState:
+        """
+        Return an enum indicating the current ac power state
+        """
+        return self._data["ac_in_state"]
+
+    def get_ac_in_power(self) -> float:
+        """
+        Return the current AC power draw
+        """
+        return self._data["ac_in_power"]
+
+    def get_ac_out_power(self) -> float:
+        """
+        Return the current AC power output
+        """
+        return self._data["ac_out_power"]
+
+    def get_battery_current(self) -> float:
+        """
+        Return the battery current in amps (positive for charging, negative for inverting)
+        """
+        return self._data["battery_current"]
+
+    def get_battery_voltage(self) -> float:
+        """
+        Return the battery voltage in volts
+        """
+        return self._data["battery_voltage"]
+
+    def get_battery_temperature(self) -> float:
+        """
+        Return the battery temperature in degrees celcius
+        """
+        return self._data["battery_temperature"]
+
+    def get_soc(self) -> float:
+        """
+        Return the battery state of charge as a percentage
+        """
+        return self._data["soc"]
+
+
+class VEBus(Device):
+    PACKET = Struct(
+        # Device state (docs do not explain how to interpret)
+        "device_state" / Int8ul,
+        # VE.Bus error (docs do not explain how to interpret)
+        "vebus_error" / Int8ul,
+        # Battery charging Current reading in 0.1A increments
+        "battery_current" / Int16sl,
+        # Battery voltage reading in 0.01V increments (14 bits)
+        # Active AC in state (enum) (2 bits)
+        "battery_voltage_and_ac_in_state" / Int16ul,
+        # Active AC in power in 1W increments (19 bits, signed)
+        # AC out power in 1W increments (19 bits, signed)
+        # Alarm (enum but docs say "to be defined") (2 bits)
+        "ac_in_and_ac_out_power" / Bytes(5),
+        # Battery temperature in 1 degree celcius increments (7 bits)
+        # Battery state of charge in 1% increments (7 bits)
+        "battery_temperature_and_soc" / Bytes(2),
+        GreedyBytes,
+    )
+
+    def parse(self, data: bytes) -> VEBusData:
+        decrypted = self.decrypt(data)
+        pkt = self.PACKET.parse(decrypted)
+
+        battery_voltage = pkt.battery_voltage_and_ac_in_state & 0x3FFF
+
+        ac_in_state = pkt.battery_voltage_and_ac_in_state >> 14
+
+        ac_in_bytes = int.from_bytes(pkt.ac_in_and_ac_out_power[0:3], "little")
+        ac_in_power = ac_in_bytes & 0x03FFFF
+        if ac_in_bytes & 0x80000:
+            ac_in_power *= -1
+
+        ac_out_bytes = int.from_bytes(pkt.ac_in_and_ac_out_power[2:5], "little") >> 2
+        ac_out_power = (ac_out_bytes >> 1) & 0x07FFFF
+        if ac_out_bytes & 0b1:
+            ac_out_power *= -1
+
+        # per extra-manufacturer-data-2022-12-14.pdf, the actual temp is 40 degrees less
+        battery_temperature = (pkt.battery_temperature_and_soc[0] & 0x46) - 40
+
+        # confusingly, soc is split across the byte boundary
+        soc = ((pkt.battery_temperature_and_soc[1] & 0x3F) << 1) + (
+            pkt.battery_temperature_and_soc[0] >> 7
+        )
+
+        parsed = {
+            "device_state": OperationMode(pkt.device_state),
+            "battery_voltage": battery_voltage / 100,
+            "battery_current": pkt.battery_current / 10,
+            "ac_in_state": ACInState(ac_in_state),
+            "ac_in_power": ac_in_power,
+            "ac_out_power": ac_out_power,
+            "battery_temperature": battery_temperature,
+            "soc": soc if soc < 127 else None,
+        }
+
+        return VEBusData(self.get_model_id(data), parsed)


### PR DESCRIPTION
### Summary :memo:
Hi, I added support for the "VE.Bus" entry in [extra-manufacturer-data-2022-12-14.pdf](https://github.com/keshavdv/victron-ble/files/11055089/extra-manufacturer-data-2022-12-14.pdf). I've tested this locally with a Victron Multiplus inverter/charger connected to a VE.Bus smart dongle and it seems to be working fine.

### Details
I added an enum for the inverter state. Otherwise I was able to use the existing enums. I tried to match it as closely to the format of the other plugins.

The VEBus advertisement uses some very strange bit lengths, which require reading extra bits to respect the byte boundaries and then masking them. It doesn't make for the most readable code but it matches the Victron spec and produces accurate values.

This is a great project, please let me know if there are other things I can do to help.

### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval
