### PR TITLE
Check the first byte of the encryption key

### DIFF
--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -1,4 +1,7 @@
+import pytest
+
 from victron_ble.devices.battery_monitor import BatteryMonitor, AuxMode
+from victron_ble.exceptions import AdvertisementKeyMismatchError
 
 
 class TestBatteryMonitor:
@@ -39,3 +42,10 @@ class TestBatteryMonitor:
             bytes.fromhex(data)
         )
         assert actual.get_temperature() == 382.2
+
+    def test_key_mismatch(self) -> None:
+        data = "100289a302bb01af129087600b9b97bc2c32867c8238da"
+        with pytest.raises(AdvertisementKeyMismatchError):
+            BatteryMonitor("ffffffffffffffffffffffffffffffff").parse(
+                bytes.fromhex(data)
+            )

--- a/victron_ble/exceptions.py
+++ b/victron_ble/exceptions.py
@@ -4,3 +4,7 @@ class UnknownDeviceError(Exception):
 
 class AdvertisementKeyMissingError(Exception):
     pass
+
+
+class AdvertisementKeyMismatchError(Exception):
+    pass


### PR DESCRIPTION
The first byte of the message is a check-byte to see that we have the correct decryption key.

This implements the check, and raises a (new) exception if it fails.

Part of: #17