### PR TITLE
Refactor parsing: Separate out decryption

### DIFF
--- a/tests/test_battery_monitor.py
+++ b/tests/test_battery_monitor.py
@@ -1,12 +1,14 @@
-from victron_ble.devices.battery_monitor import BatteryMonitor, AuxMode
+from victron_ble.devices.battery_monitor import (
+    BatteryMonitor, BatteryMonitorData, AuxMode)
 
 
 class TestBatteryMonitor:
-    def test_parse_data(self) -> None:
+    def test_end_to_end_parse(self) -> None:
         data = "100289a302b040af925d09a4d89aa0128bdef48c6298a9"
         actual = BatteryMonitor("aff4d0995b7d1e176c0c33ecb9e70dcd").parse(
             bytes.fromhex(data)
         )
+        assert isinstance(actual, BatteryMonitorData)
         assert actual.get_aux_mode() == AuxMode.DISABLED
         assert actual.get_consumed_ah() == 50.0
         assert actual.get_current() == 0
@@ -19,23 +21,33 @@ class TestBatteryMonitor:
         assert actual.get_midpoint_voltage() == None
         assert actual.get_model_name() == "SmartShunt 500A/50mV"
 
-    def test_aux_midpoint(self) -> None:
-        data = "100289a3021001afc15f433b2663c8cfc0678b5d3d29a8"
-        actual = BatteryMonitor("aff4d0995b7d1e176c0c33ecb9e70dcd").parse(
-            bytes.fromhex(data)
+    def parse_decrypted(self, decrypted: str) -> BatteryMonitorData:
+        parsed = BatteryMonitor(None).parse_decrypted(
+            bytes.fromhex(decrypted)
         )
+        return BatteryMonitorData(None, parsed)
+
+    def test_parse(self) -> None:
+        actual = self.parse_decrypted("ffffe50400000000030000f40140df03")
+        assert actual.get_aux_mode() == AuxMode.DISABLED
+        assert actual.get_consumed_ah() == 50.0
+        assert actual.get_current() == 0
+        assert actual.get_remaining_mins() == 65535
+        assert actual.get_soc() == 50.0
+        assert actual.get_voltage() == 12.53
+        assert actual.get_alarm() == None
+        assert actual.get_temperature() == None
+        assert actual.get_starter_voltage() == None
+        assert actual.get_midpoint_voltage() == None
+
+    def test_aux_midpoint(self) -> None:
+        actual = self.parse_decrypted("ffffe6040000feff010000000080fe0c")
         assert actual.get_midpoint_voltage() == 655.34
 
     def test_aux_starter(self) -> None:
-        data = "100289a302c802af45fc59d010dd78d2948e0c55c3bf48"
-        actual = BatteryMonitor("aff4d0995b7d1e176c0c33ecb9e70dcd").parse(
-            bytes.fromhex(data)
-        )
+        actual = self.parse_decrypted("ffffe6040000feff000000000080feac")
         assert actual.get_starter_voltage() == -0.02
 
     def test_aux_temperature(self) -> None:
-        data = "100289a302bb01af129087600b9b97bc2c32867c8238da"
-        actual = BatteryMonitor("aff4d0995b7d1e176c0c33ecb9e70dcd").parse(
-            bytes.fromhex(data)
-        )
+        actual = self.parse_decrypted("ffffe6040000ffff020000000080fede")
         assert actual.get_temperature() == 382.2

--- a/tests/test_battery_sense.py
+++ b/tests/test_battery_sense.py
@@ -1,19 +1,28 @@
-from victron_ble.devices import BatterySense
+from victron_ble.devices.battery_sense import BatterySense, BatterySenseData
 
 
 class TestBatterySense:
-    def test_parse_data(self) -> None:
+    def test_end_to_end_parse(self) -> None:
         key = "0da694539597f9cf6c613cde60d7bf05"
         data = "1000a4a3025f150d8dcbff517f30eb65e76b22a04ac4e1"
         actual = BatterySense(key).parse(bytes.fromhex(data))
+        assert isinstance(actual, BatterySenseData)
         assert actual.get_temperature() == 22.5
         assert actual.get_voltage() == 12.22
         assert actual.get_model_name() == "Smart Battery Sense"
 
+    def parse_decrypted(self, decrypted: str) -> BatterySenseData:
+        parsed = BatterySense(None).parse_decrypted(
+            bytes.fromhex(decrypted)
+        )
+        return BatterySenseData(None, parsed)
+
+    def test_parse(self) -> None:
+        actual = self.parse_decrypted("ffffc60400007d73feff7fffffffff12")
+        assert actual.get_temperature() == 22.5
+        assert actual.get_voltage() == 12.22
+
     def test_parse_data_new_model(self) -> None:
-        key = "fee810239c3f4fb775703a4666569569"
-        data = "1000a5a3025a0dfec57db3d1493c0b132132210f70475b"
-        actual = BatterySense(key).parse(bytes.fromhex(data))
+        actual = self.parse_decrypted("fffff80400008971feff7fffffffff5c")
         assert actual.get_temperature() == 17.5
         assert actual.get_voltage() == 12.72
-        assert actual.get_model_name() == "Smart Battery Sense"

--- a/tests/test_dc_energy_meter.py
+++ b/tests/test_dc_energy_meter.py
@@ -1,14 +1,15 @@
 from victron_ble.devices.battery_monitor import AuxMode
-from victron_ble.devices.dc_energy_meter import DcEnergyMeter, MeterType
+from victron_ble.devices.dc_energy_meter import DcEnergyMeter, DcEnergyMeterData, MeterType
 
 
 class TestDcEnergyMeter:
-    def test_parse_data(self) -> None:
+    def test_end_to_end_parse(self) -> None:
         data = "100289a30d787fafde83ccec982199fd815286"
         actual = DcEnergyMeter("aff4d0995b7d1e176c0c33ecb9e70dcd").parse(
             bytes.fromhex(data)
         )
 
+        assert isinstance(actual, DcEnergyMeterData)
         assert actual.get_meter_type() == MeterType.FUEL_CELL
         assert actual.get_aux_mode() == AuxMode.STARTER_VOLTAGE
         assert actual.get_current() == 0.0
@@ -20,16 +21,26 @@ class TestDcEnergyMeter:
         assert actual.get_temperature() == None
         assert actual.get_model_name() == "SmartShunt 500A/50mV"
 
-    def test_aux_starter(self) -> None:
-        data = "100289a30d787fafde83ccec982199fd815286"
-        actual = DcEnergyMeter("aff4d0995b7d1e176c0c33ecb9e70dcd").parse(
-            bytes.fromhex(data)
+    def parse_decrypted(self, decrypted: str) -> DcEnergyMeterData:
+        parsed = DcEnergyMeter(None).parse_decrypted(
+            bytes.fromhex(decrypted)
         )
+        return DcEnergyMeterData(None, parsed)
+
+    def test_parse(self) -> None:
+        actual = self.parse_decrypted("fdffe4040000ffff00000059a65a1c8c")
+        assert actual.get_meter_type() == MeterType.FUEL_CELL
+        assert actual.get_aux_mode() == AuxMode.STARTER_VOLTAGE
+        assert actual.get_current() == 0.0
+        assert actual.get_voltage() == 12.52
+        assert actual.get_starter_voltage() == -0.01
+        assert actual.get_alarm() == None
+        assert actual.get_temperature() == None
+
+    def test_aux_starter(self) -> None:
+        actual = self.parse_decrypted("fdffe4040000ffff00000059a65a1c8c")
         assert actual.get_starter_voltage() == -0.01
 
     def test_aux_temperature(self) -> None:
-        data = "108289a30df07faf9629bfb8c0153f431362c4"
-        actual = DcEnergyMeter("aff4d0995b7d1e176c0c33ecb9e70dcd").parse(
-            bytes.fromhex(data)
-        )
+        actual = self.parse_decrypted("fdffe4040000ffff020000ae28af8a5c")
         assert actual.get_temperature() == 382.2

--- a/tests/test_dcdc_converter.py
+++ b/tests/test_dcdc_converter.py
@@ -1,13 +1,14 @@
-from victron_ble.devices.dcdc_converter import DcDcConverter
+from victron_ble.devices.dcdc_converter import DcDcConverter, DcDcConverterData
 from victron_ble.devices.base import OperationMode, OffReason, ChargerError
 
 
 class TestDcDcConverter:
-    def test_parse_data(self) -> None:
+    def test_end_to_end_parse(self) -> None:
         data = "1000c0a304121d64ca8d442b90bbdf6a8cba"
         actual = DcDcConverter("64ba49f1a8562e45197a8e1fe50d7658").parse(
             bytes.fromhex(data)
         )
+        assert isinstance(actual, DcDcConverterData)
 
         assert actual.get_charge_state() == OperationMode.OFF
         assert actual.get_charger_error() == ChargerError.NO_ERROR
@@ -17,3 +18,17 @@ class TestDcDcConverter:
         assert (
             actual.get_model_name() == "Orion Smart 12V|12V-18A Isolated DC-DC Charger"
         )
+
+    def parse_decrypted(self, decrypted: str) -> DcDcConverterData:
+        parsed = DcDcConverter(None).parse_decrypted(
+            bytes.fromhex(decrypted)
+        )
+        return DcDcConverterData(None, parsed)
+
+    def test_parse(self) -> None:
+        actual = self.parse_decrypted("00002305ff7f80000000cbdd494cc5d1")
+        assert actual.get_charge_state() == OperationMode.OFF
+        assert actual.get_charger_error() == ChargerError.NO_ERROR
+        assert actual.get_input_voltage() == 13.15
+        assert actual.get_output_voltage() == 0
+        assert actual.get_off_reason() == OffReason.ENGINE_SHUTDOWN

--- a/tests/test_solar_charger.py
+++ b/tests/test_solar_charger.py
@@ -1,14 +1,15 @@
-from victron_ble.devices.solar_charger import SolarCharger
+from victron_ble.devices.solar_charger import SolarCharger, SolarChargerData
 from victron_ble.devices.base import OperationMode
 
 
 class TestSolarChargwer:
-    def test_parse_data(self) -> None:
+    def test_end_to_end_parse(self) -> None:
         data = "100242a0016207adceb37b605d7e0ee21b24df5c"
         actual = SolarCharger("adeccb947395801a4dd45a2eaa44bf17").parse(
             bytes.fromhex(data)
         )
 
+        assert isinstance(actual, SolarChargerData)
         assert actual.get_charge_state() == OperationMode.ABSORPTION
         assert actual.get_battery_voltage() == 13.88
         assert actual.get_battery_charging_current() == 1.4
@@ -17,22 +18,30 @@ class TestSolarChargwer:
         assert actual.get_external_device_load() == 0.0
         assert actual.get_model_name() == "BlueSolar MPPT 75|15"
 
-    def test_bulk_charge(self) -> None:
-        data = "100242a0015939a26cc2941a491e766be8457386"
-        actual = SolarCharger("a2781bef23aecd48d6b9397350724c67").parse(
-            bytes.fromhex(data)
+    def parse_decrypted(self, decrypted: str) -> SolarChargerData:
+        parsed = SolarCharger(None).parse_decrypted(
+            bytes.fromhex(decrypted)
         )
+        return SolarChargerData(None, parsed)
+
+    def test_parse(self) -> None:
+        actual = self.parse_decrypted("04006c050e000300130000fe409ac069")
+        assert actual.get_charge_state() == OperationMode.ABSORPTION
+        assert actual.get_battery_voltage() == 13.88
+        assert actual.get_battery_charging_current() == 1.4
+        assert actual.get_yield_today() == 30
+        assert actual.get_solar_power() == 19
+        assert actual.get_external_device_load() == 0.0
+
+    def test_bulk_charge(self) -> None:
+        actual = self.parse_decrypted("0300f80402000200030000fe8c9a5572")
         assert actual.get_charge_state() == OperationMode.BULK
 
     def test_parse_mppt100(self) -> None:
-        data = "100249a0013a399bbb3e36d7237c7687f96e45dc"
-        actual = SolarCharger("9b3509d3d7aba706846214ca64500d0c").parse(
-            bytes.fromhex(data)
-        )
+        actual = self.parse_decrypted("0300fb09650032000901ffff31bc45ad")
         assert actual.get_battery_charging_current() == 10.1
         assert actual.get_battery_voltage() == 25.55
         assert actual.get_charge_state() == OperationMode.BULK
         assert actual.get_solar_power() == 265
         assert actual.get_yield_today() == 500
         assert actual.get_external_device_load() is None
-        assert actual.get_model_name() == "BlueSolar MPPT 100|50 rev2"

--- a/victron_ble/devices/battery_monitor.py
+++ b/victron_ble/devices/battery_monitor.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Optional
+from typing import Optional, Type
 
 from construct import GreedyBytes, Int16sl, Int16ul, Int24sl, Struct
 
@@ -79,6 +79,7 @@ class BatteryMonitorData(DeviceData):
 
 
 class BatteryMonitor(Device):
+    data_type: Type[DeviceData] = BatteryMonitorData
     PACKET = Struct(
         # Remaining time in minutes
         "remaining_mins" / Int16ul,
@@ -105,8 +106,7 @@ class BatteryMonitor(Device):
         GreedyBytes,
     )
 
-    def parse(self, data: bytes) -> BatteryMonitorData:
-        decrypted = self.decrypt(data)
+    def parse_decrypted(self, decrypted: bytes) -> dict:
         pkt = self.PACKET.parse(decrypted)
 
         aux_mode = AuxMode(pkt.current & 0b11)
@@ -131,4 +131,4 @@ class BatteryMonitor(Device):
         elif aux_mode == AuxMode.TEMPERATURE:
             parsed["temperature_kelvin"] = pkt.aux / 100
 
-        return BatteryMonitorData(self.get_model_id(data), parsed)
+        return parsed

--- a/victron_ble/devices/battery_sense.py
+++ b/victron_ble/devices/battery_sense.py
@@ -1,4 +1,5 @@
-from victron_ble.devices import BatteryMonitor, Device, DeviceData
+from victron_ble.devices.base import DeviceData, kelvin_to_celsius
+from victron_ble.devices.battery_monitor import BatteryMonitor
 
 
 class BatterySenseData(DeviceData):
@@ -6,7 +7,7 @@ class BatterySenseData(DeviceData):
         """
         Return the temperature in Celsius
         """
-        return self._data["temperature"]
+        return kelvin_to_celsius(self._data["temperature_kelvin"])
 
     def get_voltage(self) -> float:
         """
@@ -15,11 +16,5 @@ class BatterySenseData(DeviceData):
         return self._data["voltage"]
 
 
-class BatterySense(Device):
-    def parse(self, data: bytes) -> BatterySenseData:
-        parsed = BatteryMonitor(self.advertisement_key).parse(data)
-
-        return BatterySenseData(
-            self.get_model_id(data),
-            {"temperature": parsed.get_temperature(), "voltage": parsed.get_voltage()},
-        )
+class BatterySense(BatteryMonitor):
+    data_type = BatterySenseData

--- a/victron_ble/devices/dc_energy_meter.py
+++ b/victron_ble/devices/dc_energy_meter.py
@@ -75,6 +75,8 @@ class DcEnergyMeterData(DeviceData):
 
 
 class DcEnergyMeter(Device):
+    data_type = DcEnergyMeterData
+
     PACKET = Struct(
         "meter_type" / Int16sl,
         # Voltage reading in 10mV increments
@@ -92,8 +94,7 @@ class DcEnergyMeter(Device):
         "current" / Int24sl,
     )
 
-    def parse(self, data: bytes) -> DcEnergyMeterData:
-        decrypted = self.decrypt(data)
+    def parse_decrypted(self, decrypted: bytes) -> dict:
         pkt = self.PACKET.parse(decrypted)
 
         aux_mode = AuxMode(pkt.current & 0b11)
@@ -114,4 +115,4 @@ class DcEnergyMeter(Device):
         elif aux_mode == AuxMode.TEMPERATURE:
             parsed["temperature_kelvin"] = pkt.aux / 100
 
-        return DcEnergyMeterData(self.get_model_id(data), parsed)
+        return parsed

--- a/victron_ble/devices/dcdc_converter.py
+++ b/victron_ble/devices/dcdc_converter.py
@@ -42,6 +42,8 @@ class DcDcConverterData(DeviceData):
 
 
 class DcDcConverter(Device):
+    data_type = DcDcConverterData
+
     PACKET = Struct(
         # Charge State:   0 - Off
         #                 3 - Bulk
@@ -59,11 +61,10 @@ class DcDcConverter(Device):
         GreedyBytes,
     )
 
-    def parse(self, data: bytes) -> DcDcConverterData:
-        decrypted = self.decrypt(data)
+    def parse_decrypted(self, decrypted: bytes) -> dict:
         pkt = self.PACKET.parse(decrypted)
 
-        parsed = {
+        return {
             "device_state": OperationMode(pkt.device_state),
             "charger_error": ChargerError(pkt.charger_error),
             "input_voltage": pkt.input_voltage / 100,
@@ -72,5 +73,3 @@ class DcDcConverter(Device):
             else pkt.output_voltage / 100,
             "off_reason": OffReason(pkt.off_reason),
         }
-
-        return DcDcConverterData(self.get_model_id(data), parsed)

--- a/victron_ble/devices/solar_charger.py
+++ b/victron_ble/devices/solar_charger.py
@@ -46,6 +46,8 @@ class SolarChargerData(DeviceData):
 
 
 class SolarCharger(Device):
+    data_type = SolarChargerData
+
     PACKET = Struct(
         # Charge State:   0 - Off
         #                 3 - Bulk
@@ -65,11 +67,10 @@ class SolarCharger(Device):
         "external_device_load" / Int16ul,
     )
 
-    def parse(self, data: bytes) -> SolarChargerData:
-        decrypted = self.decrypt(data)
+    def parse_decrypted(self, decrypted: bytes) -> dict:
         pkt = self.PACKET.parse(decrypted)
 
-        parsed = {
+        return {
             "charge_state": OperationMode(pkt.charge_state),
             "battery_voltage": pkt.battery_voltage / 100,
             "battery_charging_current": pkt.battery_charging_current / 10,
@@ -77,5 +78,3 @@ class SolarCharger(Device):
             "solar_power": pkt.solar_power,
             "external_device_load": pkt.external_device_load,
         }
-
-        return SolarChargerData(self.get_model_id(data), parsed)


### PR DESCRIPTION
Move decryption out of the model-specific parse function. This simplifies each device, and simplifies tests.
Keep one end-to-end test for each type of object.

We can now more easily fabricate test data for corner cases like NA values.