### PR TITLE
catch N/A value for solar charger load output

### DIFF
--- a/victron_ble/devices/solar_charger.py
+++ b/victron_ble/devices/solar_charger.py
@@ -75,7 +75,9 @@ class SolarCharger(Device):
             "battery_charging_current": pkt.battery_charging_current / 10,
             "yield_today": pkt.yield_today * 10,
             "solar_power": pkt.solar_power,
-            "external_device_load": pkt.external_device_load,
+            "external_device_load": 0
+            if pkt.external_device_load == 0x1FF
+            else pkt.external_device_load,
         }
 
         return SolarChargerData(self.get_model_id(data), parsed)


### PR DESCRIPTION
### Summary :memo:
added if-statement to catch a possible "not available" value of 0x1FF and return 0 in that case.

### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval
