### PR TITLE
Parser for Home Assistant

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ bluetooth-sensor-state-data>=1.6.1
 click>=8.0.0
 construct>=2.0
 pycryptodome>=3.0.0
+sensor-state-data>=2.16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 bleak>=0.19.0
+bluetooth-sensor-state-data>=1.6.1
 click>=8.0.0
 construct>=2.0
 pycryptodome>=3.0.0

--- a/victron_ble/devices/__init__.py
+++ b/victron_ble/devices/__init__.py
@@ -3,7 +3,11 @@ from typing import Dict, Optional, Type
 from construct import Int8ul, Int16ul
 
 from victron_ble.devices.base import Device, DeviceData
-from victron_ble.devices.battery_monitor import AuxMode, BatteryMonitor, BatteryMonitorData
+from victron_ble.devices.battery_monitor import (
+    AuxMode,
+    BatteryMonitor,
+    BatteryMonitorData,
+)
 from victron_ble.devices.battery_sense import BatterySense, BatterySenseData
 from victron_ble.devices.dc_energy_meter import DcEnergyMeter, DcEnergyMeterData
 from victron_ble.devices.dcdc_converter import DcDcConverter, DcDcConverterData

--- a/victron_ble/parser/__init__.py
+++ b/victron_ble/parser/__init__.py
@@ -1,0 +1,11 @@
+"""A parser module for use by Home Assistant."""
+
+from .custom_state_data import SensorDeviceClass, Units, Keys
+from .parser import VictronBluetoothDeviceData
+
+__all__ = [
+    "Keys",
+    "Units",
+    "SensorDeviceClass",
+    "VictronBluetoothDeviceData",
+]

--- a/victron_ble/parser/custom_state_data.py
+++ b/victron_ble/parser/custom_state_data.py
@@ -1,0 +1,70 @@
+"""Custom state data for victron-ble. See https://github.com/Bluetooth-Devices/sensor-state-data/pull/47."""
+
+import sensor_state_data
+import sensor_state_data.enum
+
+
+class SensorDeviceClass(sensor_state_data.BaseDeviceClass):
+    """Custom class to support victron-ble specific device classes."""
+
+    # inherited fields
+
+    BATTERY = sensor_state_data.DeviceClass.BATTERY
+    CURRENT = sensor_state_data.DeviceClass.CURRENT
+    DURATION = sensor_state_data.DeviceClass.DURATION
+    ENERGY = sensor_state_data.DeviceClass.ENERGY
+    POWER = sensor_state_data.DeviceClass.POWER
+    SIGNAL_STRENGTH = sensor_state_data.DeviceClass.SIGNAL_STRENGTH
+    TEMPERATURE = sensor_state_data.DeviceClass.TEMPERATURE
+    VOLTAGE = sensor_state_data.DeviceClass.VOLTAGE
+
+    # new fields
+
+    CURRENT_FLOW = "current_flow"
+    ENUM = "enum"
+
+
+class Units(sensor_state_data.enum.StrEnum):
+    """Custom class to support victron-ble specific units."""
+
+    # inherited fields
+
+    ELECTRIC_CURRENT_AMPERE = sensor_state_data.Units.ELECTRIC_CURRENT_AMPERE
+    ELECTRIC_POTENTIAL_VOLT = sensor_state_data.Units.ELECTRIC_POTENTIAL_VOLT
+    ENERGY_WATT_HOUR = sensor_state_data.Units.ENERGY_WATT_HOUR
+    PERCENTAGE = sensor_state_data.Units.PERCENTAGE
+    POWER_WATT = sensor_state_data.Units.POWER_WATT
+    TEMP_CELSIUS = sensor_state_data.Units.TEMP_CELSIUS
+    TIME_MINUTES = sensor_state_data.Units.TIME_MINUTES
+
+    # new fields
+
+    ELECTRIC_CURRENT_FLOW_AMPERE_HOUR = "Ah"
+
+
+class Keys(sensor_state_data.enum.StrEnum):
+    """Class of victron-ble keys."""
+
+    AC_IN_POWER = "ac_in_power"
+    AC_IN_STATE = "ac_in_state"
+    AC_OUT_POWER = "ac_out_power"
+    AC_OUT_STATE = "ac_out_state"
+    ALARM = "alarm"
+    AUX_MODE = "aux_mode"
+    BATTERY_CURRENT = "battery_current"
+    BATTERY_TEMPERATURE = "battery_temperature"
+    BATTERY_VOLTAGE = "battery_voltage"
+    CHARGE_STATE = "charge_state"
+    CONSUMED_AMPERE_HOURS = "consumed_ampere_hours"
+    CURRENT = "current"
+    DEVICE_STATE = "device_state"
+    EXTERNAL_DEVICE_LOAD = "external_device_load"
+    METER_TYPE = "meter_type"
+    MIDPOINT_VOLTAGE = "midpoint_voltage"
+    REMAINING_MINUTES = "remaining_minutes"
+    SOLAR_POWER = "solar_power"
+    STARTER_VOLTAGE = "starter_voltage"
+    STATE_OF_CHARGE = "state_of_charge"
+    TEMPERATURE = "temperature"
+    VOLTAGE = "voltage"
+    YIELD_TODAY = "yield_today"

--- a/victron_ble/parser/parser.py
+++ b/victron_ble/parser/parser.py
@@ -1,0 +1,311 @@
+"""Data class for Victron BLE suitable for Home Assistant integration."""
+
+import logging
+
+from bluetooth_sensor_state_data import BluetoothData
+
+from construct import StreamError
+from home_assistant_bluetooth import BluetoothServiceInfo
+
+from victron_ble.parser.custom_state_data import Keys, SensorDeviceClass, Units
+
+from victron_ble.devices import (
+    BatteryMonitor,
+    BatteryMonitorData,
+    DcEnergyMeter,
+    DcEnergyMeterData,
+    SolarCharger,
+    SolarChargerData,
+    VEBus,
+    VEBusData,
+    detect_device_type,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+VICTRON_IDENTIFIER = 0x02E1
+
+
+class VictronBluetoothDeviceData(BluetoothData):
+    """Class to hold Victron BLE device data."""
+
+    def __init__(self, advertisement_key: str | None = None) -> None:
+        """Initialize the Victron Bluetooth device data with an encryption key."""
+        super().__init__()
+        self._advertisement_key: str | None = advertisement_key
+
+    def validate_advertisement_key(self, data: bytes) -> bool:
+        """Validate the advertisement key."""
+        if not self._advertisement_key:
+            _LOGGER.debug("Advertisement key not set")
+            return False
+
+        parser = detect_device_type(data)
+        if parser is None:
+            _LOGGER.error("Unable to detect device type")
+            return False
+
+        parsed_data = parser.PARSER.parse(data)
+        if parsed_data is None:
+            _LOGGER.error("Unable to parse data")
+            return False
+
+        encrypted_data = parsed_data.encrypted_data
+
+        if encrypted_data[0] != bytes.fromhex(self._advertisement_key)[0]:
+            # only possible check is whether the first byte matches
+            _LOGGER.error("Advertisement key does not match")
+            return False
+
+        return True
+
+    def _start_update(self, data: BluetoothServiceInfo) -> None:
+        try:
+            raw_data = data.manufacturer_data[VICTRON_IDENTIFIER]
+        except (KeyError, IndexError):
+            # not a Victron device
+            return
+
+        if not raw_data.startswith(b"\x10"):
+            # not an instant-update advertisement
+            return
+
+        try:
+            parser = detect_device_type(raw_data)
+        except StreamError:
+            _LOGGER.debug("Malformed advertisement %s", raw_data.hex())
+            return
+        if parser is None:
+            _LOGGER.debug("Ignoring unsupported advertisement %s", raw_data.hex())
+            return
+        if not issubclass(parser, (BatteryMonitor, DcEnergyMeter, SolarCharger, VEBus)):
+            _LOGGER.debug("Unsupported device type")
+            return
+        self.set_device_manufacturer(data.manufacturer or "Victron")
+        self.set_device_name(data.name)
+        self.set_device_type(parser.__name__)
+        if not self.validate_advertisement_key(raw_data):
+            return
+        assert self._advertisement_key is not None  # keep pylance happy
+
+        try:
+            parsed_data = parser(self._advertisement_key).parse(raw_data)
+        except ValueError:
+            parsed_data = None
+        if parsed_data is None:
+            _LOGGER.debug("Unable to parse data")
+            return
+        if isinstance(parsed_data, BatteryMonitorData):
+            self._update_battery_monitor(parsed_data)
+        elif isinstance(parsed_data, DcEnergyMeterData):
+            self._update_dc_energy_meter(parsed_data)
+        elif isinstance(parsed_data, SolarChargerData):
+            self._update_solar_charger(parsed_data)
+        elif isinstance(parsed_data, VEBusData):
+            self._update_vebus(parsed_data)
+
+    def _update_battery_monitor(self, data: BatteryMonitorData) -> None:
+        self.update_sensor(
+            Keys.REMAINING_MINUTES,
+            Units.TIME_MINUTES,  # type: ignore [arg-type]
+            data.get_remaining_mins(),
+            SensorDeviceClass.DURATION,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.CURRENT,
+            Units.ELECTRIC_CURRENT_AMPERE,  # type: ignore [arg-type]
+            data.get_current(),
+            SensorDeviceClass.CURRENT,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.VOLTAGE,
+            Units.ELECTRIC_POTENTIAL_VOLT,  # type: ignore [arg-type]
+            data.get_voltage(),
+            SensorDeviceClass.VOLTAGE,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.STATE_OF_CHARGE,
+            Units.PERCENTAGE,  # type: ignore [arg-type]
+            data.get_soc(),
+            SensorDeviceClass.BATTERY,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.CONSUMED_AMPERE_HOURS,
+            Units.ELECTRIC_CURRENT_FLOW_AMPERE_HOUR,  # type: ignore [arg-type]
+            data.get_consumed_ah(),
+            SensorDeviceClass.CURRENT_FLOW,  # type: ignore [arg-type]
+        )
+        alarm = data.get_alarm()
+        if alarm is not None:
+            alarm_string = alarm.name
+        else:
+            alarm_string = "no alarm"
+        self.update_sensor(
+            Keys.ALARM,
+            None,
+            alarm_string,
+        )
+        self.update_sensor(
+            Keys.AUX_MODE,
+            None,
+            data.get_aux_mode().name,
+        )
+        self.update_sensor(
+            Keys.TEMPERATURE,
+            Units.TEMP_CELSIUS,  # type: ignore [arg-type]
+            data.get_temperature(),
+            SensorDeviceClass.TEMPERATURE,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.STARTER_VOLTAGE,
+            Units.ELECTRIC_POTENTIAL_VOLT,  # type: ignore [arg-type]
+            data.get_starter_voltage(),
+            SensorDeviceClass.VOLTAGE,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.MIDPOINT_VOLTAGE,
+            Units.ELECTRIC_POTENTIAL_VOLT,  # type: ignore [arg-type]
+            data.get_midpoint_voltage(),
+            SensorDeviceClass.VOLTAGE,  # type: ignore [arg-type]
+        )
+
+    def _update_dc_energy_meter(self, data: DcEnergyMeterData) -> None:
+        meter_type = data.get_meter_type()
+        if meter_type is not None:
+            meter_type_string = meter_type.name
+        else:
+            meter_type_string = None
+        self.update_sensor(
+            Keys.METER_TYPE,
+            None,
+            meter_type_string,
+        )
+        self.update_sensor(
+            Keys.CURRENT,
+            Units.ELECTRIC_CURRENT_AMPERE,  # type: ignore [arg-type]
+            data.get_current(),
+            SensorDeviceClass.CURRENT,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.VOLTAGE,
+            Units.ELECTRIC_POTENTIAL_VOLT,  # type: ignore [arg-type]
+            data.get_voltage(),
+            SensorDeviceClass.VOLTAGE,  # type: ignore [arg-type]
+        )
+        alarm = data.get_alarm()
+        self.update_sensor(
+            Keys.ALARM,
+            None,
+            alarm.name if alarm else None,
+        )
+        self.update_sensor(
+            Keys.TEMPERATURE,
+            Units.TEMP_CELSIUS,  # type: ignore [arg-type]
+            data.get_temperature(),
+            SensorDeviceClass.TEMPERATURE,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.AUX_MODE,
+            None,
+            data.get_aux_mode().name,
+        )
+        self.update_sensor(
+            Keys.TEMPERATURE,
+            Units.TEMP_CELSIUS,  # type: ignore [arg-type]
+            data.get_temperature(),
+            SensorDeviceClass.TEMPERATURE,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.STARTER_VOLTAGE,
+            Units.ELECTRIC_POTENTIAL_VOLT,  # type: ignore [arg-type]
+            data.get_starter_voltage(),
+            SensorDeviceClass.VOLTAGE,  # type: ignore [arg-type]
+        )
+
+    def _update_solar_charger(self, data: SolarChargerData) -> None:
+        charge_state = data.get_charge_state()
+        self.update_sensor(
+            Keys.CHARGE_STATE,
+            None,
+            charge_state.name if charge_state else None,
+        )
+        self.update_sensor(
+            Keys.BATTERY_VOLTAGE,
+            Units.ELECTRIC_POTENTIAL_VOLT,  # type: ignore [arg-type]
+            data.get_battery_voltage(),
+            SensorDeviceClass.VOLTAGE,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.BATTERY_CURRENT,
+            Units.ELECTRIC_CURRENT_AMPERE,  # type: ignore [arg-type]
+            data.get_battery_charging_current(),
+            SensorDeviceClass.CURRENT,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.YIELD_TODAY,
+            Units.ENERGY_WATT_HOUR,  # type: ignore [arg-type]
+            data.get_yield_today(),
+            SensorDeviceClass.ENERGY,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.SOLAR_POWER,
+            Units.POWER_WATT,  # type: ignore [arg-type]
+            data.get_solar_power(),
+            SensorDeviceClass.POWER,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.EXTERNAL_DEVICE_LOAD,
+            Units.ELECTRIC_CURRENT_AMPERE,  # type: ignore [arg-type]
+            data.get_external_device_load(),
+            SensorDeviceClass.CURRENT,  # type: ignore [arg-type]
+        )
+
+    def _update_vebus(self, data: VEBusData) -> None:
+        device_state = data.get_device_state()
+        self.update_sensor(
+            Keys.DEVICE_STATE,
+            None,
+            device_state.name if device_state else None,
+        )
+        ac_in_state = data.get_ac_in_state()
+        self.update_sensor(
+            Keys.AC_IN_STATE,
+            None,
+            ac_in_state.name if ac_in_state else None,
+        )
+        self.update_sensor(
+            Keys.AC_IN_POWER,
+            Units.POWER_WATT,  # type: ignore [arg-type]
+            data.get_ac_in_power(),
+            SensorDeviceClass.POWER,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.AC_OUT_POWER,
+            Units.POWER_WATT,  # type: ignore [arg-type]
+            data.get_ac_out_power(),
+            SensorDeviceClass.POWER,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.BATTERY_CURRENT,
+            Units.ELECTRIC_CURRENT_AMPERE,  # type: ignore [arg-type]
+            data.get_battery_current(),
+            SensorDeviceClass.CURRENT,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.BATTERY_VOLTAGE,
+            Units.ELECTRIC_POTENTIAL_VOLT,  # type: ignore [arg-type]
+            data.get_battery_voltage(),
+            SensorDeviceClass.VOLTAGE,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.BATTERY_TEMPERATURE,
+            Units.TEMP_CELSIUS,  # type: ignore [arg-type]
+            data.get_battery_temperature(),
+            SensorDeviceClass.TEMPERATURE,  # type: ignore [arg-type]
+        )
+        self.update_sensor(
+            Keys.STATE_OF_CHARGE,
+            Units.PERCENTAGE,  # type: ignore [arg-type]
+            data.get_soc(),
+            SensorDeviceClass.BATTERY,  # type: ignore [arg-type]
+        )

--- a/victron_ble/parser/parser.py
+++ b/victron_ble/parser/parser.py
@@ -136,14 +136,10 @@ class VictronBluetoothDeviceData(BluetoothData):
             SensorDeviceClass.CURRENT_FLOW,  # type: ignore [arg-type]
         )
         alarm = data.get_alarm()
-        if alarm is not None:
-            alarm_string = alarm.name
-        else:
-            alarm_string = "no alarm"
         self.update_sensor(
             Keys.ALARM,
             None,
-            alarm_string,
+            alarm.name if alarm else "no alarm",
         )
         self.update_sensor(
             Keys.AUX_MODE,
@@ -196,7 +192,7 @@ class VictronBluetoothDeviceData(BluetoothData):
         self.update_sensor(
             Keys.ALARM,
             None,
-            alarm.name if alarm else None,
+            alarm.name if alarm else "no alarm",
         )
         self.update_sensor(
             Keys.TEMPERATURE,


### PR DESCRIPTION
### Summary :memo:
To integrate with Home Assistant core, they've asked that I move some of the logic from the HA component to the Python library. This PR does that by creating a new module called `parser` that handles incoming Bluetooth advertisements in a way that integrates cleanly with HA.

If you'd rather I spin this into a separate project I can do that too, but I thought it would be cleaner to have everything in one dependency.

I've tested locally with these changes, and once this is merged and a new version released, I can push my local changes to the PR for HA core (https://github.com/home-assistant/core/pull/94994#pullrequestreview-1498141714)

### Details
1. The `parser` module has one class, `VictronBluetoothDeviceData`, which parses Bleak advertisements and updates itself with the sensor data from the advertisement. Each instance of `VictronBluetoothDeviceData` should be fed advertisements from exactly one Victron device (based on the MAC address) and the instance needs to be initiated with the encryption key of the device that is going to be sending updates. If the encryption key is set correctly everything else will be figured out automatically.

2. There is a handy package from maintainers of the HA project called `sensor-state-data` to make it easy to automate ingesting sensor state updates like this. Unfortunately, we need to use a unit (amp-hours) not supported by the module and my PR to include amp-hours was rejected because they are not a common unit (https://github.com/Bluetooth-Devices/sensor-state-data/pull/47). For that reason, we need a custom extension of `sensor-state-data`, which is contained in the `custom-sensor-state.py` file.

### Checks
- [X] Tested Changes
- [ ] Stakeholder Approval
