### PR TITLE
Add initial support for smart lithium batteries

### DIFF
--- a/tests/test_smart_lithium.py
+++ b/tests/test_smart_lithium.py
@@ -67,3 +67,13 @@ class TestSmartLithium:
             None,
         ]
         assert actual.get_error_flags() == 0
+
+    def test_parse_4(self) -> None:
+        actual = self.parse_decrypted(
+            b'\x00\x00\x00\x06\x00\x00G\xa3\xd1h,\x1a\x8dP\n\xcd\x96d\xf2\xf5\x0b\x85\xed\xe8h\xf6\x1d\xc1\xae\xa1\xce\x83')
+        assert actual.get_balancer_status() == 0
+        assert actual.get_battery_temperature() == 37
+        assert actual.get_battery_voltage() == 26.4
+        assert actual.get_bms_flags() == 6 #?
+        assert actual.get_cell_voltages() == [
+            3.31, 3.30, 3.30, 3.30, 3.30, 3.29, 3.30, 3.30]

--- a/tests/test_smart_lithium.py
+++ b/tests/test_smart_lithium.py
@@ -1,0 +1,69 @@
+import pytest
+
+from victron_ble.devices.smart_lithium import SmartLithium, SmartLithiumData
+
+
+class TestSmartLithium:
+    def parse_decrypted(self, decrypted: bytes) -> SmartLithiumData:
+        parsed = SmartLithium(None).parse_decrypted(decrypted)
+        return SmartLithiumData(None, parsed)
+
+    def test_parse(self) -> None:
+        actual = self.parse_decrypted(
+            b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xf1\xf8\xff\xff\xff,5\xb5\xfa\xb4x\x01\x0f\xd2I\xd2\xae_iV\xe1\xf8\xa9e"
+        )
+        assert actual.get_balancer_status() == 5
+        assert actual.get_battery_temperature() == 50  # TODO this should be around 10C
+        assert actual.get_battery_voltage() == 7.07  # TODO this should be >13
+        assert actual.get_bms_flags() == 6
+        assert actual.get_cell_voltages() == [
+            3.59,
+            3.8,
+            float("inf"),
+            2.91,
+            3.31,
+            None,
+            None,
+            None,
+        ]
+        assert actual.get_error_flags() == 0
+
+    def test_parse_2(self) -> None:
+        actual = self.parse_decrypted(
+            b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xf1\xf8\xff\xff\xff,\x15\xb6\x84\x9a\xea \x97}\x8c\xa2\xb6\xf92\xde\x82\x8a\x88\xf9"
+        )
+        assert actual.get_balancer_status() == 5
+        assert actual.get_battery_temperature() == 51  # TODO this should be around 10C
+        assert actual.get_battery_voltage() == 7.05  # TODO this should be >13
+        assert actual.get_bms_flags() == 6
+        assert actual.get_cell_voltages() == [
+            3.59,
+            3.8,
+            float("inf"),
+            2.91,
+            3.31,
+            None,
+            None,
+            None,
+        ]  # TODO this is random, but for some reason the same as with the other battery...
+        assert actual.get_error_flags() == 0
+
+    def test_parse_3(self) -> None:
+        actual = self.parse_decrypted(
+            b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xd1\xf8\xff\xff\xff+5\xb5[\xe5\x93\xfd93\xe4\x1c?C\xcefA\xe7q\xa3"
+        )
+        assert actual.get_balancer_status() == 5
+        assert actual.get_battery_temperature() == 50  # TODO this should be around 10C
+        assert actual.get_battery_voltage() == 6.91  # TODO this should be >13
+        assert actual.get_bms_flags() == 6
+        assert actual.get_cell_voltages() == [
+            3.59,
+            3.8,
+            3.8200000000000003,
+            2.91,
+            3.31,
+            None,
+            None,
+            None,
+        ]  # TODO this is random, but for some reason ALMOST the same as with the other battery...
+        assert actual.get_error_flags() == 0

--- a/tests/test_smart_lithium.py
+++ b/tests/test_smart_lithium.py
@@ -1,6 +1,10 @@
 import pytest
 
-from victron_ble.devices.smart_lithium import SmartLithium, SmartLithiumData
+from victron_ble.devices.smart_lithium import (
+    SmartLithium,
+    SmartLithiumData,
+    BalancerStatus,
+)
 
 
 class TestSmartLithium:
@@ -12,7 +16,7 @@ class TestSmartLithium:
         actual = self.parse_decrypted(
             b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xf1\xf8\xff\xff\xff,5\xb5\xfa\xb4x\x01\x0f\xd2I\xd2\xae_iV\xe1\xf8\xa9e"
         )
-        assert actual.get_balancer_status() == 3
+        assert actual.get_balancer_status() == BalancerStatus.IMBALANCE
         assert actual.get_battery_temperature() == 13
         assert actual.get_battery_voltage() == 13.24
         assert actual.get_bms_flags() == 6
@@ -32,7 +36,7 @@ class TestSmartLithium:
         actual = self.parse_decrypted(
             b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xf1\xf8\xff\xff\xff,\x15\xb6\x84\x9a\xea \x97}\x8c\xa2\xb6\xf92\xde\x82\x8a\x88\xf9"
         )
-        assert actual.get_balancer_status() == 1
+        assert actual.get_balancer_status() == BalancerStatus.BALANCED
         assert actual.get_battery_temperature() == 14
         assert actual.get_battery_voltage() == 13.24
         assert actual.get_bms_flags() == 6
@@ -52,7 +56,7 @@ class TestSmartLithium:
         actual = self.parse_decrypted(
             b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xd1\xf8\xff\xff\xff+5\xb5[\xe5\x93\xfd93\xe4\x1c?C\xcefA\xe7q\xa3"
         )
-        assert actual.get_balancer_status() == 3
+        assert actual.get_balancer_status() == BalancerStatus.IMBALANCE
         assert actual.get_battery_temperature() == 13
         assert actual.get_battery_voltage() == 13.23
         assert actual.get_bms_flags() == 6
@@ -70,20 +74,38 @@ class TestSmartLithium:
 
     def test_parse_4(self) -> None:
         actual = self.parse_decrypted(
-            b'\x00\x00\x00\x06\x00\x00G\xa3\xd1h,\x1a\x8dP\n\xcd\x96d\xf2\xf5\x0b\x85\xed\xe8h\xf6\x1d\xc1\xae\xa1\xce\x83')
-        assert actual.get_balancer_status() == 0
+            b"\x00\x00\x00\x06\x00\x00G\xa3\xd1h,\x1a\x8dP\n\xcd\x96d\xf2\xf5\x0b\x85\xed\xe8h\xf6\x1d\xc1\xae\xa1\xce\x83"
+        )
+        assert actual.get_balancer_status() == BalancerStatus.UNKNOWN
         assert actual.get_battery_temperature() == 37
         assert actual.get_battery_voltage() == 26.4
-        assert actual.get_bms_flags() == 6 #?
+        assert actual.get_bms_flags() == 6  # ?
         assert actual.get_cell_voltages() == [
-            3.31, 3.30, 3.30, 3.30, 3.30, 3.29, 3.30, 3.30]
+            3.31,
+            3.30,
+            3.30,
+            3.30,
+            3.30,
+            3.29,
+            3.30,
+            3.30,
+        ]
 
     def test_parse_5(self) -> None:
         actual = self.parse_decrypted(
-            b'\x00\x00\x00\x06\x00\x00\xcc\xe5\x92\xb9\\.\x99{\x1a\xd0P%\xcf\xa5\xa6\xb2[\x91<T\x85\xee\x85by\xae')
-        assert actual.get_balancer_status() == 1
+            b"\x00\x00\x00\x06\x00\x00\xcc\xe5\x92\xb9\\.\x99{\x1a\xd0P%\xcf\xa5\xa6\xb2[\x91<T\x85\xee\x85by\xae"
+        )
+        assert actual.get_balancer_status() == BalancerStatus.BALANCED
         assert actual.get_battery_temperature() == 40
         assert actual.get_battery_voltage() == 26.83
-        assert actual.get_bms_flags() == 6 #?
+        assert actual.get_bms_flags() == 6  # ?
         assert actual.get_cell_voltages() == [
-            3.36, 3.35, 3.35, 3.36, 3.35, 3.35, 3.35, 3.36]
+            3.36,
+            3.35,
+            3.35,
+            3.36,
+            3.35,
+            3.35,
+            3.35,
+            3.36,
+        ]

--- a/tests/test_smart_lithium.py
+++ b/tests/test_smart_lithium.py
@@ -12,16 +12,16 @@ class TestSmartLithium:
         actual = self.parse_decrypted(
             b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xf1\xf8\xff\xff\xff,5\xb5\xfa\xb4x\x01\x0f\xd2I\xd2\xae_iV\xe1\xf8\xa9e"
         )
-        assert actual.get_balancer_status() == 5
-        assert actual.get_battery_temperature() == 50  # TODO this should be around 10C
-        assert actual.get_battery_voltage() == 7.07  # TODO this should be >13
+        assert actual.get_balancer_status() == 3
+        assert actual.get_battery_temperature() == 13
+        assert actual.get_battery_voltage() == 13.24
         assert actual.get_bms_flags() == 6
         assert actual.get_cell_voltages() == [
-            3.59,
-            3.8,
-            float("inf"),
-            2.91,
             3.31,
+            3.31,
+            3.31,
+            3.31,
+            None,
             None,
             None,
             None,
@@ -32,38 +32,38 @@ class TestSmartLithium:
         actual = self.parse_decrypted(
             b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xf1\xf8\xff\xff\xff,\x15\xb6\x84\x9a\xea \x97}\x8c\xa2\xb6\xf92\xde\x82\x8a\x88\xf9"
         )
-        assert actual.get_balancer_status() == 5
-        assert actual.get_battery_temperature() == 51  # TODO this should be around 10C
-        assert actual.get_battery_voltage() == 7.05  # TODO this should be >13
+        assert actual.get_balancer_status() == 1
+        assert actual.get_battery_temperature() == 14
+        assert actual.get_battery_voltage() == 13.24
         assert actual.get_bms_flags() == 6
         assert actual.get_cell_voltages() == [
-            3.59,
-            3.8,
-            float("inf"),
-            2.91,
+            3.31,
+            3.31,
+            3.31,
             3.31,
             None,
             None,
             None,
-        ]  # TODO this is random, but for some reason the same as with the other battery...
+            None,
+        ]
         assert actual.get_error_flags() == 0
 
     def test_parse_3(self) -> None:
         actual = self.parse_decrypted(
             b"\x00\x00\x00\x06\x00\x00\xc7\xe3\xd1\xf8\xff\xff\xff+5\xb5[\xe5\x93\xfd93\xe4\x1c?C\xcefA\xe7q\xa3"
         )
-        assert actual.get_balancer_status() == 5
-        assert actual.get_battery_temperature() == 50  # TODO this should be around 10C
-        assert actual.get_battery_voltage() == 6.91  # TODO this should be >13
+        assert actual.get_balancer_status() == 3
+        assert actual.get_battery_temperature() == 13
+        assert actual.get_battery_voltage() == 13.23
         assert actual.get_bms_flags() == 6
         assert actual.get_cell_voltages() == [
-            3.59,
-            3.8,
-            3.8200000000000003,
-            2.91,
             3.31,
+            3.31,
+            3.31,
+            3.3,
             None,
             None,
             None,
-        ]  # TODO this is random, but for some reason ALMOST the same as with the other battery...
+            None,
+        ]
         assert actual.get_error_flags() == 0

--- a/tests/test_smart_lithium.py
+++ b/tests/test_smart_lithium.py
@@ -77,3 +77,13 @@ class TestSmartLithium:
         assert actual.get_bms_flags() == 6 #?
         assert actual.get_cell_voltages() == [
             3.31, 3.30, 3.30, 3.30, 3.30, 3.29, 3.30, 3.30]
+
+    def test_parse_5(self) -> None:
+        actual = self.parse_decrypted(
+            b'\x00\x00\x00\x06\x00\x00\xcc\xe5\x92\xb9\\.\x99{\x1a\xd0P%\xcf\xa5\xa6\xb2[\x91<T\x85\xee\x85by\xae')
+        assert actual.get_balancer_status() == 1
+        assert actual.get_battery_temperature() == 40
+        assert actual.get_battery_voltage() == 26.83
+        assert actual.get_bms_flags() == 6 #?
+        assert actual.get_cell_voltages() == [
+            3.36, 3.35, 3.35, 3.36, 3.35, 3.35, 3.35, 3.36]

--- a/victron_ble/devices/__init__.py
+++ b/victron_ble/devices/__init__.py
@@ -3,7 +3,11 @@ from typing import Dict, Optional, Type
 from construct import Int8ul, Int16ul
 
 from victron_ble.devices.base import Device, DeviceData
-from victron_ble.devices.battery_monitor import AuxMode, BatteryMonitor, BatteryMonitorData
+from victron_ble.devices.battery_monitor import (
+    AuxMode,
+    BatteryMonitor,
+    BatteryMonitorData,
+)
 from victron_ble.devices.battery_sense import BatterySense, BatterySenseData
 from victron_ble.devices.dc_energy_meter import DcEnergyMeter, DcEnergyMeterData
 from victron_ble.devices.dcdc_converter import DcDcConverter, DcDcConverterData

--- a/victron_ble/devices/__init__.py
+++ b/victron_ble/devices/__init__.py
@@ -11,6 +11,7 @@ from victron_ble.devices.battery_monitor import (
 from victron_ble.devices.battery_sense import BatterySense, BatterySenseData
 from victron_ble.devices.dc_energy_meter import DcEnergyMeter, DcEnergyMeterData
 from victron_ble.devices.dcdc_converter import DcDcConverter, DcDcConverterData
+from victron_ble.devices.smart_lithium import SmartLithium, SmartLithiumData
 from victron_ble.devices.solar_charger import SolarCharger, SolarChargerData
 from victron_ble.devices.vebus import VEBus, VEBusData
 
@@ -26,6 +27,8 @@ __all__ = [
     "DcDcConverterData",
     "DcEnergyMeter",
     "DcEnergyMeterData",
+    "SmartLithium",
+    "SmartLithiumData",
     "SolarCharger",
     "SolarChargerData",
     "VEBus",
@@ -66,8 +69,10 @@ def detect_device_type(data: bytes) -> Optional[Type[Device]]:
         pass
     elif mode == 0xB:  # MultiRS
         pass
-    elif mode == 0x5:  # SmartLithium
-        pass
+    elif (
+        mode == 0x5
+    ):  # SmartLithium (commercially Lithium Battery Smart / LiFePO4 Battery Smart)
+        return SmartLithium
     elif mode == 0x1:  # SolarCharger
         return SolarCharger
     elif mode == 0xC:  # VE.Bus

--- a/victron_ble/devices/base.py
+++ b/victron_ble/devices/base.py
@@ -263,6 +263,7 @@ MODEL_ID_MAPPING = {
     0xA071: "BlueSolar MPPT 150|70 rev2",
     0xA0EC: "SmartLithium Battery 12V/160Ah",
     0xA0EE: "SmartLithium Battery 24V/200Ah",
+    0xA0F0: "SmartLithium Battery 12V/330Ah",
     0xA102: "SmartSolar MPPT VE.Can 150/70",
     0xA103: "SmartSolar MPPT VE.Can 150/45",
     0xA104: "SmartSolar MPPT VE.Can 150/60",

--- a/victron_ble/devices/base.py
+++ b/victron_ble/devices/base.py
@@ -261,6 +261,7 @@ MODEL_ID_MAPPING = {
     0xA06F: "BlueSolar MPPT 150|45 rev2",
     0xA070: "BlueSolar MPPT 150|60 rev2",
     0xA071: "BlueSolar MPPT 150|70 rev2",
+    0xA0EE: "SmartLithium Battery 24V/200Ah",
     0xA102: "SmartSolar MPPT VE.Can 150/70",
     0xA103: "SmartSolar MPPT VE.Can 150/45",
     0xA104: "SmartSolar MPPT VE.Can 150/60",

--- a/victron_ble/devices/base.py
+++ b/victron_ble/devices/base.py
@@ -261,6 +261,7 @@ MODEL_ID_MAPPING = {
     0xA06F: "BlueSolar MPPT 150|45 rev2",
     0xA070: "BlueSolar MPPT 150|60 rev2",
     0xA071: "BlueSolar MPPT 150|70 rev2",
+    0xA0EC: "SmartLithium Battery 12V/160Ah",
     0xA0EE: "SmartLithium Battery 24V/200Ah",
     0xA102: "SmartSolar MPPT VE.Can 150/70",
     0xA103: "SmartSolar MPPT VE.Can 150/45",

--- a/victron_ble/devices/dcdc_converter.py
+++ b/victron_ble/devices/dcdc_converter.py
@@ -68,8 +68,8 @@ class DcDcConverter(Device):
             "device_state": OperationMode(pkt.device_state),
             "charger_error": ChargerError(pkt.charger_error),
             "input_voltage": pkt.input_voltage / 100,
-            "output_voltage": 0
-            if pkt.output_voltage == 0x7FFF
-            else pkt.output_voltage / 100,
+            "output_voltage": (
+                0 if pkt.output_voltage == 0x7FFF else pkt.output_voltage / 100
+            ),
             "off_reason": OffReason(pkt.off_reason),
         }

--- a/victron_ble/devices/smart_lithium.py
+++ b/victron_ble/devices/smart_lithium.py
@@ -53,7 +53,7 @@ class SmartLithium(Device):
         BitStruct(
             Padding(1),  # unused
             "battery_temperature" / BitsInteger(7),  # -40..86C
-            "balancer_status" / BitsInteger(4),
+            "balancer_status" / BitsInteger(4),  # 0 = not balanced, 1 = balanced
             "battery_voltage" / BitsInteger(12),  # (0V.. +0.01V .. 40.95V)
             # Cell voltage reading 7 bit * 8 cells (0x00<2.61V, 0x01=2.61V, +0.01V .. 0x7e>3.85V, 0x7f N/A)
             "cell_voltages" / Array(8, BitsInteger(7)),
@@ -87,5 +87,5 @@ class SmartLithium(Device):
 
 def parse_cell_voltage(payload: int) -> Optional[float]:
     return {0x00: float("-inf"), 0x7E: float("inf"), 0x7F: None}.get(
-        payload, 2.60 + payload / 100.0
+        payload, (260 + payload) / 100.0
     )

--- a/victron_ble/devices/smart_lithium.py
+++ b/victron_ble/devices/smart_lithium.py
@@ -53,7 +53,7 @@ class SmartLithium(Device):
         BitStruct(
             Padding(1),  # unused
             "battery_temperature" / BitsInteger(7),  # -40..86C
-            "balancer_status" / BitsInteger(4),  # 0 = not balanced, 1 = balanced
+            "balancer_status" / BitsInteger(4),  # 0 = Imbalance, 1 = balanced, 3 = Imbalance
             "battery_voltage" / BitsInteger(12),  # (0V.. +0.01V .. 40.95V)
             # Cell voltage reading 7 bit * 8 cells (0x00<2.61V, 0x01=2.61V, +0.01V .. 0x7e>3.85V, 0x7f N/A)
             "cell_voltages" / Array(8, BitsInteger(7)),

--- a/victron_ble/devices/smart_lithium.py
+++ b/victron_ble/devices/smart_lithium.py
@@ -1,0 +1,85 @@
+from typing import Optional
+
+from construct import Array, BitsInteger, BitStruct, Padding
+
+from victron_ble.devices.base import Device, DeviceData
+
+
+class SmartLithiumData(DeviceData):
+    def get_bms_flags(self) -> int:
+        """
+        Get the raw bms_flags field (meaning not documented).
+        """
+        return self._data["bms_flags"]
+
+    def get_error_flags(self) -> int:
+        """
+        Get the raw error_flags field (meaning not documented).
+        """
+        return self._data["error_flags"]
+
+    def get_battery_voltage(self) -> Optional[float]:
+        """
+        Return the voltage in volts
+        """
+        return self._data["battery_voltage"]
+
+    def get_battery_temperature(self) -> int:
+        """
+        Return the temperature in Celsius if the aux input is set to temperature
+        """
+        return self._data["battery_temperature"]
+
+    def get_cell_voltages(self) -> list:
+        """
+        Return the voltage of each cell (floats where -inf is <2.61V, +inf is >3.85V, None is N/A)
+        """
+        return self._data["cell_voltages"]
+
+    def get_balancer_status(self) -> int:
+        """
+        Get the raw balancer_status field (meaning not documented).
+        """
+        return self._data["balancer_status"]
+
+
+class SmartLithium(Device):
+    data_type = SmartLithiumData
+
+    # https://community.victronenergy.com/questions/187303/victron-bluetooth-advertising-protocol.html
+    PACKET = BitStruct(
+        "bms_flags" / BitsInteger(32),
+        "error_flags" / BitsInteger(16),
+        # Cell voltage reading 7 bit * 8 cells (0x00<2.61V, 0x01=2.61V, +0.01V .. 0x7e>3.85V, 0x7f N/A)
+        "cell_voltages" / Array(8, BitsInteger(7)),
+        "battery_voltage" / BitsInteger(12),  # (0V.. +0.01V .. 40.95V)
+        "balancer_status" / BitsInteger(4),
+        "battery_temperature" / BitsInteger(7),  # -40..86C
+        Padding(1),  # unused
+    )
+
+    def parse_decrypted(self, decrypted: bytes) -> dict:
+        pkt = self.PACKET.parse(decrypted)
+
+        parsed = {
+            "bms_flags": pkt.bms_flags,
+            "error_flags": pkt.error_flags,
+            "cell_voltages": [parse_cell_voltage(v) for v in pkt.cell_voltages],
+            "battery_voltage": (
+                pkt.battery_voltage / 100.0 if pkt.battery_voltage != 0x0FFF else None
+            ),
+            "balancer_status": pkt.balancer_status,
+            "battery_temperature": (
+                (pkt.battery_temperature - 40)
+                if pkt.battery_temperature != 0x7F
+                else None
+            ),  # Celsius
+        }
+
+        return parsed
+
+
+def parse_cell_voltage(payload: int) -> Optional[float]:
+    return {0x00: float("-inf"), 0x7E: float("inf"), 0x7F: None}.get(
+        payload, 2.60 + payload / 100.0
+    )

--- a/victron_ble/devices/smart_lithium.py
+++ b/victron_ble/devices/smart_lithium.py
@@ -4,7 +4,7 @@ from construct import Array, BitsInteger, BitStruct, ByteSwapped, Padding
 
 from victron_ble.devices.base import Device, DeviceData
 
-from enum Import Enum
+from enum import Enum
 
 class BalancerStatus(Enum):
   UNKNOWN = 0

--- a/victron_ble/devices/smart_lithium.py
+++ b/victron_ble/devices/smart_lithium.py
@@ -9,6 +9,7 @@ from enum import Enum
 class BalancerStatus(Enum):
   UNKNOWN = 0
   BALANCED = 1
+  BALANCING = 2 //?
   IMBALANCE = 3
   
 class SmartLithiumData(DeviceData):

--- a/victron_ble/devices/smart_lithium.py
+++ b/victron_ble/devices/smart_lithium.py
@@ -1,17 +1,18 @@
+from enum import Enum
 from typing import Optional
 
 from construct import Array, BitsInteger, BitStruct, ByteSwapped, Padding
 
 from victron_ble.devices.base import Device, DeviceData
 
-from enum import Enum
 
 class BalancerStatus(Enum):
-  UNKNOWN = 0
-  BALANCED = 1
-  BALANCING = 2 //?
-  IMBALANCE = 3
-  
+    UNKNOWN = 0
+    BALANCED = 1
+    BALANCING = 2
+    IMBALANCE = 3
+
+
 class SmartLithiumData(DeviceData):
     def get_bms_flags(self) -> int:
         """
@@ -60,7 +61,8 @@ class SmartLithium(Device):
         BitStruct(
             Padding(1),  # unused
             "battery_temperature" / BitsInteger(7),  # -40..86C
-            "balancer_status" / BitsInteger(4),  # 0 = unknown, 1 = balanced, 3 = imbalance
+            "balancer_status"
+            / BitsInteger(4),  # 0 = unknown, 1 = balanced, 3 = imbalance
             "battery_voltage" / BitsInteger(12),  # (0V.. +0.01V .. 40.95V)
             # Cell voltage reading 7 bit * 8 cells (0x00<2.61V, 0x01=2.61V, +0.01V .. 0x7e>3.85V, 0x7f N/A)
             "cell_voltages" / Array(8, BitsInteger(7)),

--- a/victron_ble/devices/solar_charger.py
+++ b/victron_ble/devices/solar_charger.py
@@ -76,7 +76,7 @@ class SolarCharger(Device):
             "battery_charging_current": pkt.battery_charging_current / 10,
             "yield_today": pkt.yield_today * 10,
             "solar_power": pkt.solar_power,
-            "external_device_load": 0
-            if pkt.external_device_load == 0x1FF
-            else pkt.external_device_load,
+            "external_device_load": (
+                0 if pkt.external_device_load == 0x1FF else pkt.external_device_load
+            ),
         }


### PR DESCRIPTION
### Summary :memo:
Add initial support for smart lithium batteries

### Details
I've implemented the parsing based on the [pdf](https://community.victronenergy.com/storage/attachments/48745-extra-manufacturer-data-2022-12-14.pdf) and tested on a bunch of 160Ah batteries.  @stefanor worked together with Victron to fix the byte order, and the data gathered with this code seems to match what the VictronConnect app says.

### Checks
- [x] Tested Changes
- [ ] Stakeholder Approval
