### PR TITLE
Output JSON which is on a single line

### DIFF
--- a/victron_ble/cli.py
+++ b/victron_ble/cli.py
@@ -61,7 +61,7 @@ def read(device_keys: List[Tuple[str, str]]):
     loop = asyncio.get_event_loop()
 
     async def scan(keys):
-        scanner = Scanner(keys)
+        scanner = Scanner(keys, indent=None)
         await scanner.start()
 
     asyncio.ensure_future(scan({k: v for k, v in device_keys}))

--- a/victron_ble/scanner.py
+++ b/victron_ble/scanner.py
@@ -64,10 +64,11 @@ class DeviceDataEncoder(json.JSONEncoder):
 
 
 class Scanner(BaseScanner):
-    def __init__(self, device_keys: dict[str, str] = {}):
+    def __init__(self, device_keys: dict[str, str] = {}, indent = 2):
         super().__init__()
         self._device_keys = {k.lower(): v for k, v in device_keys.items()}
         self._known_devices: dict[str, Device] = {}
+        self._indent = indent
 
     async def start(self):
         logger.info(f"Reading data for {list(self._device_keys.keys())}")
@@ -112,7 +113,7 @@ class Scanner(BaseScanner):
             "rssi": ble_device.rssi,
             "payload": parsed,
         }
-        print(json.dumps(blob, cls=DeviceDataEncoder, indent=2))
+        print(json.dumps(blob, cls=DeviceDataEncoder, indent=self._indent), flush=True)
 
 
 class DiscoveryScanner(BaseScanner):


### PR DESCRIPTION
### Summary :memo:

This patch formats JSON on a single line

### Details

Outputting JSON on single line helps to parse the payload programmatically. This is a proposal since I'd like to get your opinion about should this be the default format or should there be a command-line option which is straightforward to add since I already added the formatting option to the constructor.