### PR TITLE
Include requirements*.txt in sdists

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,7 @@
 include LICENSE
 include HISTORY.md
 include Containerfile
+include requirements.txt
+include requirements-test.txt
 graft tests
 graft victron_ble


### PR DESCRIPTION
`setup.py` expects them to be present and reads them. Without them, the `sdists` are useless.