### PR TITLE
Update setup.py to reflect license

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ def read_requirements(path):
 setup(
     name="victron_ble",
     version=read("victron_ble", "VERSION"),
+    license="Unlicense",
     description="Python API to read Victron Instant Readout advertisements",
     url="https://github.com/keshavdv/victron-ble/",
     long_description=read("README.md"),


### PR DESCRIPTION
### Summary :memo:
The home assistant maintainers run automated license checks that rely on [pypi classifiers](https://pypi.org/classifiers/). I've updated setup.py to reflect the fact that this project is released under the unlicense.

### Checks
- [ ] Closed #798
- [ ] Tested Changes
- [ ] Stakeholder Approval
