### PR TITLE
Update base.py

### DIFF
--- a/victron_ble/devices/base.py
+++ b/victron_ble/devices/base.py
@@ -982,6 +982,7 @@ MODEL_ID_MAPPING = {
     0xC035: "SmartShunt IP65 500A/50mV",
     0xC036: "SmartShunt IP65 1000A/50mV",
     0xC037: "SmartShunt IP65 2000A/50mV",
+    0xC038: "SmartShunt 300A/50mV"
 }
 
 


### PR DESCRIPTION
Added model ID for SmartShunt 300A/50mV

### Summary :memo:
Added model ID for SmartShunt 300A/50mV - 0xC038/49208

### Details
_Describe more what you did on changes._
1. Added the new model ID to the list in base.py

### Checks
None TBH