### PR TITLE
Obtain rssi from `AdvertisementData`

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@ _Describe more what you did on changes._
 1. (...)
 2. (...)
 
-### Bugfixes :bug: (delete if dind't have any)
+### Bugfixes :bug: (delete if didn't have any)
 -
 
 ### Checks

--- a/tests/test_scanner_callback.py
+++ b/tests/test_scanner_callback.py
@@ -1,0 +1,52 @@
+import json
+from unittest.mock import patch
+from victron_ble.scanner import Scanner
+
+class DummyDevice:
+    def __init__(self, address="AA:BB:CC:DD:EE:FF", name="TestDevice"):
+        self.address = address
+        self.name = name
+
+class DummyDeviceType:
+    def __init__(self, key):
+        self.key = key
+    def parse(self, raw_data):
+        return {"parsed": True}
+
+def test_callback_with_none_rssi(monkeypatch):
+    scanner = Scanner(device_keys={"aa:bb:cc:dd:ee:ff": "dummykey"})
+    device = DummyDevice()
+    raw_data = b"\x10\x01\x02"
+    monkeypatch.setattr("victron_ble.scanner.detect_device_type", lambda data: DummyDeviceType)
+    monkeypatch.setattr("victron_ble.scanner.DeviceDataEncoder", lambda *a, **kw: json.JSONEncoder())
+    with patch("builtins.print") as mock_print:
+        scanner.callback(device, raw_data, rssi=None)
+        mock_print.assert_called()
+        args, kwargs = mock_print.call_args
+        assert '"rssi": null' in args[0]
+
+def test_callback_with_omitted_rssi(monkeypatch):
+    scanner = Scanner(device_keys={"aa:bb:cc:dd:ee:ff": "dummykey"})
+    device = DummyDevice()
+    raw_data = b"\x10\x01\x02"
+    monkeypatch.setattr("victron_ble.scanner.detect_device_type", lambda data: DummyDeviceType)
+    monkeypatch.setattr("victron_ble.scanner.DeviceDataEncoder", lambda *a, **kw: json.JSONEncoder())
+    with patch("builtins.print") as mock_print:
+        scanner.callback(device, raw_data)
+        mock_print.assert_called()
+        args, kwargs = mock_print.call_args
+        assert '"rssi": null' in args[0]
+
+def test_callback_with_int_rssi(monkeypatch):
+    scanner = Scanner(device_keys={"aa:bb:cc:dd:ee:ff": "dummykey"})
+    device = DummyDevice()
+    raw_data = b"\x10\x01\x02"
+    monkeypatch.setattr("victron_ble.scanner.detect_device_type", lambda data: DummyDeviceType)
+    monkeypatch.setattr("victron_ble.scanner.DeviceDataEncoder", lambda *a, **kw: json.JSONEncoder())
+    with patch("builtins.print") as mock_print:
+        scanner.callback(device, raw_data, rssi=-55)
+        mock_print.assert_called()
+        args, kwargs = mock_print.call_args
+        assert '"rssi": -55' in args[0]
+
+

--- a/victron_ble/scanner.py
+++ b/victron_ble/scanner.py
@@ -36,9 +36,9 @@ class BaseScanner:
             self._seen_data = set()
         self._seen_data.add(data)
 
-        self.callback(device, data)
+        self.callback(device, data, advertisement.rssi)
 
-    def callback(self, device: BLEDevice, data: bytes):
+    def callback(self, device: BLEDevice, data: bytes, rssi: int | None = None):
         raise NotImplementedError()
 
     async def start(self):
@@ -94,7 +94,7 @@ class Scanner(BaseScanner):
         except KeyError:
             raise AdvertisementKeyMissingError(f"No key available for {address}")
 
-    def callback(self, ble_device: BLEDevice, raw_data: bytes):
+    def callback(self, ble_device: BLEDevice, raw_data: bytes, rssi: int | None = None):
         logger.debug(
             f"Received data from {ble_device.address.lower()}: {raw_data.hex()}"
         )
@@ -110,9 +110,10 @@ class Scanner(BaseScanner):
         blob = {
             "name": ble_device.name,
             "address": ble_device.address,
-            "rssi": ble_device.rssi,
             "payload": parsed,
+            "rssi": rssi,
         }
+
         print(json.dumps(blob, cls=DeviceDataEncoder, indent=self._indent), flush=True)
 
 
@@ -121,7 +122,7 @@ class DiscoveryScanner(BaseScanner):
         super().__init__()
         self._seen_devices: Set[str] = set()
 
-    def callback(self, device: BLEDevice, advertisement: bytes):
+    def callback(self, device: BLEDevice, advertisement: bytes,  rssi: int | None = None):
         if device.address not in self._seen_devices:
             logger.info(f"{device}")
             self._seen_devices.add(device.address)
@@ -136,6 +137,6 @@ class DebugScanner(BaseScanner):
         logger.info(f"Dumping advertisements from {self.address}")
         await super().start()
 
-    def callback(self, device: BLEDevice, data: bytes):
+    def callback(self, device: BLEDevice, data: bytes,  rssi: int | None = None):
         if device.address.lower() == self.address.lower():
             logger.info(f"{time.time():<24}: {data.hex()}")


### PR DESCRIPTION
### Summary :memo:

Fixes #75 - bleak has removed `BLEDevice.rssi` since v1.0.0 ([deprecation warning seen in an earlier version prior to the removal](https://github.com/hbldh/bleak/blob/b6ab16699843a9574ae0aadcca8ea79d756cebf2/bleak/backends/device.py#L47)). Within the Scanner class's `callback` method there was a call to access the `rssi` attribute on a `BLEDevice` object, however this would throw the following exception if a user had bleak v1+ installed:
```
ERROR:dbus_fast.message_bus:A message handler raised an exception: 'BLEDevice' object has no attribute 'rssi'
```

The version of bleak marked as required for the victron-ble package is >= 0.19.0, so any newcomers who haven't otherwise pinned their version of bleak will now encounter this error whenever reading data from their devices.


### Details
_Describe more what you did on changes._
1. Passed into the `callback` methods of the subclass of BaseScanner an `rssi` value from the `AdvertisementData` object provided with each device detection event.
2. `rssi` defaults to `None` if no value is available for whatever reason.


### Checks
- [ ] Closed #75 
- [X] Tested Changes
- [ ] Stakeholder Approval
